### PR TITLE
Add `.devcontainer` confguration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,32 +1,49 @@
 {
-    "name": "Smile",
-    "image": "mcr.microsoft.com/devcontainers/typescript-node:20",
+  "name": "Smile",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:20",
 
-    "features": {
-        "ghcr.io/devcontainers/features/common-utils": {
-            "installOhMyZsh": true,
-            "installZsh": true,
-            "configureZshAsDefaultShell": true,
-            "upgradePackages": true,
-        },
-    },
-
-    "workspaceMount": "source=${localWorkspaceFolder},target=/smile,type=bind,consistency=cached",
-    "workspaceFolder": "/smile",
-
-    "customizations": {
-        "vscode": {
-            "extensions": [
-                "Vue.volar",
-                "dbaeumer.vscode-eslint",
-                "esbenp.prettier-vscode",
-                "JosefBiehler.cypress-fixture-intellisense",
-                "aaron-bond.better-comments",
-                "GitHub.vscode-pull-request-github",
-                "github.vscode-github-actions",
-                "GitHub.remotehub",
-                "mikestead.dotenv"
-            ]
-        }
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils": {
+      "installOhMyZsh": true,
+      "installZsh": true,
+      "configureZshAsDefaultShell": true,
+      "upgradePackages": true
     }
+  },
+
+  "postStartCommand": "npm run dev",
+  "postCreateCommand": "./scripts/setup_project.sh && ./scripts/setup_git_hooks.sh",
+
+  "workspaceMount": "source=${localWorkspaceFolder},target=/smile,type=bind,consistency=cached",
+  "workspaceFolder": "/smile",
+
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "files.useIgnoreFiles": true,
+        "editor.wordBasedSuggestions": "matchingDocuments",
+        "editor.formatOnType": true,
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
+        "diffEditor.ignoreTrimWhitespace": false,
+        "[yaml]": {
+          "editor.defaultFormatter": "redhat.vscode-yaml"
+        },
+        "[dockerfile]": {
+          "editor.defaultFormatter": "ms-azuretools.vscode-docker"
+        }
+      },
+      "extensions": [
+        "Vue.volar",
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "JosefBiehler.cypress-fixture-intellisense",
+        "aaron-bond.better-comments",
+        "GitHub.vscode-pull-request-github",
+        "github.vscode-github-actions",
+        "mikestead.dotenv",
+        "ms-azuretools.vscode-docker",
+        "redhat.vscode-yaml"
+      ]
+    }
+  }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,32 @@
+{
+    "name": "Smile",
+    "image": "mcr.microsoft.com/devcontainers/typescript-node:20",
+
+    "features": {
+        "ghcr.io/devcontainers/features/common-utils": {
+            "installOhMyZsh": true,
+            "installZsh": true,
+            "configureZshAsDefaultShell": true,
+            "upgradePackages": true,
+        },
+    },
+
+    "workspaceMount": "source=${localWorkspaceFolder},target=/smile,type=bind,consistency=cached",
+    "workspaceFolder": "/smile",
+
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "Vue.volar",
+                "dbaeumer.vscode-eslint",
+                "esbenp.prettier-vscode",
+                "JosefBiehler.cypress-fixture-intellisense",
+                "aaron-bond.better-comments",
+                "GitHub.vscode-pull-request-github",
+                "github.vscode-github-actions",
+                "GitHub.remotehub",
+                "mikestead.dotenv"
+            ]
+        }
+    }
+}

--- a/scripts/setup_project.sh
+++ b/scripts/setup_project.sh
@@ -14,5 +14,5 @@ ln -sf ../../scripts/generate_git_env.sh .git/hooks/post-commit
 ln -sf ../../scripts/generate_git_env.sh .git/hooks/post-checkout
 bash scripts/generate_git_env.sh
 
-echo "Buliding Bulma CSS"
+echo "Building Bulma CSS"
 npm run css-build


### PR DESCRIPTION
While there's a setup for GitPod, it only allows for 50 hours for free per month (personally, I've never used GitPod either). Dev Containers have first-party support in VSCode and on GitHub Codespaces, additionally it allows for a relatively pre-configured environment to be shipped alongside the code for `smile`.

For local use, it does require the installation of Docker, so that likely needs to be documented (happy to do so), but figured I'd open this before doing any documentation on it. 🙂 

(To test, you'll need Docker installed and the ["Dev Containers" extension][extension], then you should be prompted to reopen the repo in a Dev Container.)

[extension]: https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers