### PR TITLE
Make .htaccess file and add mime type

### DIFF
--- a/.github/workflows/deploy-hash.yml
+++ b/.github/workflows/deploy-hash.yml
@@ -175,6 +175,10 @@ jobs:
           remote_user: ${{ secrets.EXP_DEPLOY_USER }}
           remote_key: ${{ secrets.EXP_DEPLOY_KEY  }}
 
+      # make .htaccess file and add wasm mime type
+      - name: create the .htaccess file and add the wasm mime type
+        run: echo "AddType application/wasm wasm" > dist/.htaccess
+
       # send a notification at the end
       - name: Send notification to lab slack
         env:


### PR DESCRIPTION
For experiments that serve a WebGL build (i.e., when serving a Unity game in the browser), MIME types need to be specified for files with the .wasm extension. The `.htaccess` file allows to add MIME types to the host server and can serve various other functions. The job added to the `deploy.yml` in this pull request creates the `.htaccess` file in the root directory of the smile experiment website and adds the appropriate MIME type needed for WebGL applications. 