### PR TITLE
Properly escaped quotes in github commit mesasge

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,6 +33,9 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
+    env:
+      GITHUB_COMMIT_MESSAGE: "${{ github.event.head_commit.message }}"
+
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -119,8 +122,8 @@ jobs:
             echo "VITE_GIT_LAST_MSG   =   (no commit message)" >> $ENV_FILE
             VITE_GIT_LAST_MSG='(no commit message)'
           else
-            echo "VITE_GIT_LAST_MSG   =   ${{ github.event.head_commit.message }}" >> $ENV_FILE
-            VITE_GIT_LAST_MSG='${{ github.event.head_commit.message }}'
+            echo "VITE_GIT_LAST_MSG   =   $GITHUB_COMMIT_MESSAGE" >> $ENV_FILE
+            VITE_GIT_LAST_MSG="$GITHUB_COMMIT_MESSAGE"
           fi
           echo "VITE_DEPLOY_BASE_PATH   =  '/${VITE_GIT_OWNER}/${VITE_GIT_REPO_NAME}/${VITE_GIT_BRANCH_NAME}/'" >> $ENV_FILE
           CODENAME=$(node scripts/codenamize.cjs "/${{ env.GITHUB_REPOSITORY_OWNER_PART_SLUG }}/${{ env.GITHUB_REPOSITORY_NAME_PART_SLUG }}/${{ env.GITHUB_REF_SLUG }}")


### PR DESCRIPTION
The same approach could be used to escape other variables as well.
Fixed #60.
Verified in this commmit that successfully deployed: https://github.com/guydav/ball-game-level-builder/commit/137f982e