### PR TITLE
Update requirements.md: change reference of npm to Node.js

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -14,9 +14,9 @@ items on your local computer.
 You will need to install Node.js on your computer. You can download the latest
 version [here](https://nodejs.org/en/download/). After the installation
 completes, verify that you have the `npm` command in your terminal program of
-choice. If you already have Node installed, verify that the version of npm is
+choice. If you already have Node installed, verify that the version of Node.js is
 greater than or equal to {{ theme.nodeVersion }}. You can check your installed
-version by typing `npm -v`.
+version by typing `node -v`.
 
 ## 2. Create a GitHub account if you haven't and install the command-line tool
 


### PR DESCRIPTION
I believe that “…verify that the version of npm is greater than or equal to 20.18.1.” is meant to verify that the version of Node.js, not npm, is greater than or equal to 20.18.1, since the latest version of npm is something like 11.x.x.