### PR TITLE
fix: properly reset instructions and quiz form

### DIFF
--- a/src/builtins/instructions/InstructionsView.vue
+++ b/src/builtins/instructions/InstructionsView.vue
@@ -38,6 +38,7 @@ const instText = computed(() => {
  * @param {boolean} [goto] - Optional parameter for navigation control (unused in current implementation)
  */
 function finish(goto) {
+  api.goFirstStep() // reset the state in case you loop back (only needed if using stepper)
   api.goNextView()
 }
 </script>

--- a/src/builtins/instructionsQuiz/InstructionsQuiz.vue
+++ b/src/builtins/instructionsQuiz/InstructionsQuiz.vue
@@ -156,11 +156,27 @@ function submitQuiz() {
 }
 
 /**
+ * Clear all answer data from quiz questions without destroying the stepper structure
+ */
+function clearQuizAnswers() {
+  // Get all page data and clear the answer property from each question
+  const pages = api.queryStepData('pages*')
+  pages.forEach((page) => {
+    if (page.questions && Array.isArray(page.questions)) {
+      page.questions.forEach((question) => {
+        delete question.answer
+      })
+    }
+  })
+}
+
+/**
  * Return to instructions page and increment attempt counter
  */
 function returnInstructions() {
-  api.goFirstStep() // reset the quiz
-  api.clear() // don't remember across reloads
+  clearQuizAnswers() // Clear answers but preserve stepper structure
+  api.goFirstStep() // reset the quiz to first page
+
   api.persist.attempts = api.persist.attempts + 1 // increment attempts
   api.goToView(props.returnTo) // go back to instructions
 }


### PR DESCRIPTION
- instructionsQuiz was not allowing repeats of the quiz if you get a question wrong in production/live mode (closes #230)
- add a `api.goFirstStep()` to the default built-in InstructionsView.vue as a hint about how to handle this in multi-page instructions