### PR TITLE
fix: error in decoding SECRET_APP_CONFIG

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -146,7 +146,7 @@ jobs:
           SECRET_ENV_FILE: 'env/.env.local'
         run: |
           echo "------"
-          echo $SECRET_APP_CONFIG | base64 --decode > $SECRET_ENV_FILE
+          echo $SECRET_APP_CONFIG | base64 --decode -i > $SECRET_ENV_FILE
 
       # load the environment
       - name: Load the github dotenv file

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -126,7 +126,7 @@ jobs:
           SECRET_ENV_FILE: 'env/.env.local'
         run: |
           echo "------"
-          echo $SECRET_APP_CONFIG | base64 --decode > $SECRET_ENV_FILE
+          echo $SECRET_APP_CONFIG | base64 --decode -i > $SECRET_ENV_FILE
 
       # load the environment
       - name: Load the github dotenv file

--- a/scripts/update_config.sh
+++ b/scripts/update_config.sh
@@ -6,9 +6,11 @@ url=$(git config --get remote.origin.url)
 repo_path=$(echo "$url" | sed -E 's|.*/([^/]+)/([^/.]+)(\.git)?|\1/\2|')
 
 
-# update the app configs using a base64 encoding of 
+# update the app configs using a base64 encoding of
 # all the variables
-ENC=$(cat env/.env.local | base64)
+# Note: Use tr -d '\n' to remove line breaks for cross-platform compatibility
+# (Linux base64 adds newlines by default, macOS doesn't)
+ENC=$(cat env/.env.local | base64 | tr -d '\n')
 gh secret set SECRET_APP_CONFIG --body "$ENC" --repo $repo_path
 
 


### PR DESCRIPTION
- This issue may fix #215 and #225
- The issue is:
  1. On Ubuntu, base64 adds line breaks every 76 characters by default
  2. When stored in GitHub Secrets, these newlines cause decoding issues

Solution:
- In update_config.sh: Use tr -d '\n' to remove newlines (cross-platform compatible with both macOS and Linux)
- In workflow files: Add -i flag to ignore invalid characters during decode (Linux only, which is fine since GitHub Actions uses ubuntu-latest)

Why these fixes work:

1. Encoding fix (tr -d '\n'): On Ubuntu/Linux, base64 adds line breaks every 76 characters by default. Using tr -d '\n' removes all newlines and is compatible with both macOS and Linux (unlike -w 0 which only works on Linux).

2. Decoding fix (-i flag): The -i flag tells base64 --decode to ignore invalid input characters. This provides resilience against any stray whitespace or other characters that might have been introduced during secret storage.